### PR TITLE
Resolve WSDL schema imports offline via jax-ws-catalog

### DIFF
--- a/src/main/resources/META-INF/jax-ws-catalog.xml
+++ b/src/main/resources/META-INF/jax-ws-catalog.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  OASIS XML Catalog auto-discovered by Apache CXF's OASISCatalogManager from every JAR
+  on the classpath at path META-INF/jax-ws-catalog.xml.
+
+  Without this catalog, Apache CXF's WSDL loader fetches the absolute schema URLs
+  referenced by xs:import in wsdl/WinRM.wsdl directly from schemas.dmtf.org and
+  www.w3.org over the network at every WinRMService.createInstance() call. On
+  offline / air-gapped / restricted-egress hosts those fetches block for ~75s
+  each (OS TCP timeout) before failing with:
+
+      javax.wsdl.WSDLException: WSDLException
+      (at /wsdl:definitions/wsdl:types/xs:schema[1]):
+       faultCode=PARSER_ERROR: Problem parsing
+       'http://schemas.dmtf.org/wbem/wsman/1/dsp8034_1.0.xsd'.:
+      java.net.ConnectException: Connection timed out
+
+  Relative <system uri="..."> values resolve against this catalog's URL inside
+  the JAR, so "../xsd/X.xsd" -> "xsd/X.xsd" at the JAR root.
+-->
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
+    <system systemId="http://schemas.dmtf.org/wbem/wsman/1/dsp8033_1.0.xsd"
+            uri="../xsd/dsp8033_1.0.xsd"/>
+    <system systemId="http://schemas.dmtf.org/wbem/wsman/1/dsp8034_1.0.xsd"
+            uri="../xsd/dsp8034_1.0.xsd"/>
+    <system systemId="http://www.w3.org/2001/xml.xsd"
+            uri="../xsd/xml.xsd"/>
+    <system systemId="http://www.w3.org/2006/03/addressing/ws-addr.xsd"
+            uri="../xsd/ws-addr.xsd"/>
+</catalog>

--- a/src/main/resources/xsd/dsp8034_1.0.xsd
+++ b/src/main/resources/xsd/dsp8034_1.0.xsd
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+DMTF - Distributed Management Task Force, Inc. - http://www.dmtf.org
+
+Document number: DSP8034
+Date: 2010-02-19
+Version: 1.0.0
+Document status: DMTF Standard
+
+Title: WS-Management Addressing XML Schema
+
+Document type: Specification (W3C XML Schema)
+Document language: E
+
+Abstract: XML Schema for WS-Management Addressing.
+
+Contact group: DMTF WS-Management Work Group, wsman-chair@dmtf.org
+
+Copyright (C) 2008,2009, 2010 Distributed Management Task Force, Inc. (DMTF).
+All rights reserved.  DMTF is a not-for-profit association of industry
+members dedicated to promoting enterprise and systems management and
+interoperability.  Members and non-members may reproduce DMTF
+specifications and documents 
+provided that correct attribution is given.  As DMTF specifications may
+be revised from time to time, the particular version and release date
+should always be noted.  Implementation of certain elements of this
+standard or proposed standard may be subject to third party patent
+rights, including provisional patent rights (herein "patent rights").
+DMTF makes no representations to users of the standard as to the
+existence of such rights, and is not responsible to recognize, disclose,
+or identify any or all such third party patent right, owners or
+claimants, nor for any incomplete or inaccurate identification or
+disclosure of such rights, owners or claimants.  DMTF shall have no
+liability to any party, in any manner or circumstance, under any legal
+theory whatsoever, for failure to recognize, disclose, or identify any
+such third party patent rights, or for such party's reliance on the
+standard or incorporation thereof in its product, protocols or testing
+procedures.  DMTF shall have no liability to any party implementing
+such standard, whether such implementation is foreseeable or not, nor
+to any patent owner or claimant, and shall have no liability or
+responsibility for costs or losses incurred if a standard is withdrawn
+or modified after publication, and shall be indemnified and held
+harmless by any party implementing the standard from any and all claims
+of infringement by a patent owner for such implementations.  For
+information about patents held by third-parties which have notified the
+DMTF that, in their opinion, such patent may relate to or impact
+implementations of DMTF standards, visit
+http://www.dmtf.org/about/policies/disclosures.php.
+
+Change log:
+1.0.0 - 2009-11-01 - Work in progress release
+1.0.0 - 2010-02-19 - DMTF Standard release
+  -->
+<xs:schema 
+  targetNamespace="http://schemas.xmlsoap.org/ws/2004/08/addressing" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" 
+  elementFormDefault="qualified" blockDefault="#all">
+
+  <!-- //////////////////// Addressing //////////////////// -->
+  <!-- Endpoint reference -->
+  <xs:element name="EndpointReference" type="wsa:EndpointReferenceType"/>
+  <xs:complexType name="EndpointReferenceType">
+    <xs:sequence>
+      <xs:element name="Address" type="wsa:AttributedURI"/>
+      <xs:element name="ReferenceProperties" 
+        type="wsa:ReferencePropertiesType" minOccurs="0"/>
+      <xs:element name="ReferenceParameters" 
+        type="wsa:ReferenceParametersType" minOccurs="0"/>
+      <xs:element name="PortType" type="wsa:AttributedQName" minOccurs="0"/>
+      <xs:element name="ServiceName" type="wsa:ServiceNameType" minOccurs="0"/>
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" 
+        maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+           If "Policy" elements from namespace 
+           "http://schemas.xmlsoap.org/ws/2002/12/policy#policy" are used, 
+           they must appear first (before any extensibility elements).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:any>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+  <xs:complexType name="ReferencePropertiesType">
+    <xs:sequence>
+      <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ReferenceParametersType">
+    <xs:sequence>
+      <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ServiceNameType">
+    <xs:simpleContent>
+      <xs:extension base="xs:QName">
+        <xs:attribute name="PortName" type="xs:NCName"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <!-- Message information header blocks -->
+  <xs:element name="MessageID" type="wsa:AttributedURI"/>
+  <xs:element name="RelatesTo" type="wsa:Relationship"/>
+  <xs:element name="To" type="wsa:AttributedURI"/>
+  <xs:element name="Action" type="wsa:AttributedURI"/>
+  <xs:element name="From" type="wsa:EndpointReferenceType"/>
+  <xs:element name="ReplyTo" type="wsa:EndpointReferenceType"/>
+  <xs:element name="FaultTo" type="wsa:EndpointReferenceType"/>
+  <xs:complexType name="Relationship">
+    <xs:simpleContent>
+      <xs:extension base="xs:anyURI">
+        <xs:attribute name="RelationshipType" type="xs:QName" use="optional"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="RelationshipTypeValues">
+    <xs:restriction base="xs:QName">
+      <xs:enumeration value="wsa:Reply"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="ReplyAfter" type="wsa:ReplyAfterType"/>
+  <xs:complexType name="ReplyAfterType">
+    <xs:simpleContent>
+      <xs:extension base="xs:nonNegativeInteger">
+        <xs:anyAttribute namespace="##other"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:element name="RetryAfter" type="wsa:RetryAfterType"/>
+  <xs:complexType name="RetryAfterType">
+    <xs:simpleContent>
+      <xs:extension base="xs:nonNegativeInteger">
+        <xs:anyAttribute namespace="##other"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="FaultSubcodeValues">
+    <xs:restriction base="xs:QName">
+      <xs:enumeration value="wsa:InvalidMessageInformationHeader"/>
+      <xs:enumeration value="wsa:MessageInformationHeaderRequired"/>
+      <xs:enumeration value="wsa:DestinationUnreachable"/>
+      <xs:enumeration value="wsa:ActionNotSupported"/>
+      <xs:enumeration value="wsa:EndpointUnavailable"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:attribute name="Action" type="xs:anyURI"/>
+  <!-- Common declarations and definitions -->
+  <xs:complexType name="AttributedQName">
+    <xs:simpleContent>
+      <xs:extension base="xs:QName">
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="AttributedURI">
+    <xs:simpleContent>
+      <xs:extension base="xs:anyURI">
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>

--- a/src/main/resources/xsd/ws-addr.xsd
+++ b/src/main/resources/xsd/ws-addr.xsd
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    W3C XML Schema defined in the Web Services Addressing 1.0 specification
+    http://www.w3.org/TR/ws-addr-core
+
+   Copyright © 2005 World Wide Web Consortium,
+
+   (Massachusetts Institute of Technology, European Research Consortium for
+   Informatics and Mathematics, Keio University). All Rights Reserved. This
+   work is distributed under the W3C® Software License [1] in the hope that
+   it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+   [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+
+   $Id: ws-addr.xsd,v 1.2 2008/07/23 13:38:16 plehegar Exp $
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.w3.org/2005/08/addressing" targetNamespace="http://www.w3.org/2005/08/addressing" blockDefault="#all" elementFormDefault="qualified" finalDefault="" attributeFormDefault="unqualified">
+	
+	<!-- Constructs from the WS-Addressing Core -->
+
+	<xs:element name="EndpointReference" type="tns:EndpointReferenceType"/>
+	<xs:complexType name="EndpointReferenceType" mixed="false">
+		<xs:sequence>
+			<xs:element name="Address" type="tns:AttributedURIType"/>
+			<xs:element ref="tns:ReferenceParameters" minOccurs="0"/>
+			<xs:element ref="tns:Metadata" minOccurs="0"/>
+			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##other" processContents="lax"/>
+	</xs:complexType>
+	
+	<xs:element name="ReferenceParameters" type="tns:ReferenceParametersType"/>
+	<xs:complexType name="ReferenceParametersType" mixed="false">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##other" processContents="lax"/>
+	</xs:complexType>
+	
+	<xs:element name="Metadata" type="tns:MetadataType"/>
+	<xs:complexType name="MetadataType" mixed="false">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##other" processContents="lax"/>
+	</xs:complexType>
+	
+	<xs:element name="MessageID" type="tns:AttributedURIType"/>
+	<xs:element name="RelatesTo" type="tns:RelatesToType"/>
+	<xs:complexType name="RelatesToType" mixed="false">
+		<xs:simpleContent>
+			<xs:extension base="xs:anyURI">
+				<xs:attribute name="RelationshipType" type="tns:RelationshipTypeOpenEnum" use="optional" default="http://www.w3.org/2005/08/addressing/reply"/>
+				<xs:anyAttribute namespace="##other" processContents="lax"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
+	<xs:simpleType name="RelationshipTypeOpenEnum">
+		<xs:union memberTypes="tns:RelationshipType xs:anyURI"/>
+	</xs:simpleType>
+	
+	<xs:simpleType name="RelationshipType">
+		<xs:restriction base="xs:anyURI">
+			<xs:enumeration value="http://www.w3.org/2005/08/addressing/reply"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
+	<xs:element name="ReplyTo" type="tns:EndpointReferenceType"/>
+	<xs:element name="From" type="tns:EndpointReferenceType"/>
+	<xs:element name="FaultTo" type="tns:EndpointReferenceType"/>
+	<xs:element name="To" type="tns:AttributedURIType"/>
+	<xs:element name="Action" type="tns:AttributedURIType"/>
+
+	<xs:complexType name="AttributedURIType" mixed="false">
+		<xs:simpleContent>
+			<xs:extension base="xs:anyURI">
+				<xs:anyAttribute namespace="##other" processContents="lax"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
+	<!-- Constructs from the WS-Addressing SOAP binding -->
+
+	<xs:attribute name="IsReferenceParameter" type="xs:boolean"/>
+	
+	<xs:simpleType name="FaultCodesOpenEnumType">
+		<xs:union memberTypes="tns:FaultCodesType xs:QName"/>
+	</xs:simpleType>
+	
+	<xs:simpleType name="FaultCodesType">
+		<xs:restriction base="xs:QName">
+			<xs:enumeration value="tns:InvalidAddressingHeader"/>
+			<xs:enumeration value="tns:InvalidAddress"/>
+			<xs:enumeration value="tns:InvalidEPR"/>
+			<xs:enumeration value="tns:InvalidCardinality"/>
+			<xs:enumeration value="tns:MissingAddressInEPR"/>
+			<xs:enumeration value="tns:DuplicateMessageID"/>
+			<xs:enumeration value="tns:ActionMismatch"/>
+			<xs:enumeration value="tns:MessageAddressingHeaderRequired"/>
+			<xs:enumeration value="tns:DestinationUnreachable"/>
+			<xs:enumeration value="tns:ActionNotSupported"/>
+			<xs:enumeration value="tns:EndpointUnavailable"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
+	<xs:element name="RetryAfter" type="tns:AttributedUnsignedLongType"/>
+	<xs:complexType name="AttributedUnsignedLongType" mixed="false">
+		<xs:simpleContent>
+			<xs:extension base="xs:unsignedLong">
+				<xs:anyAttribute namespace="##other" processContents="lax"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
+	<xs:element name="ProblemHeaderQName" type="tns:AttributedQNameType"/>
+	<xs:complexType name="AttributedQNameType" mixed="false">
+		<xs:simpleContent>
+			<xs:extension base="xs:QName">
+				<xs:anyAttribute namespace="##other" processContents="lax"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
+	<xs:element name="ProblemIRI" type="tns:AttributedURIType"/>
+	
+	<xs:element name="ProblemAction" type="tns:ProblemActionType"/>
+	<xs:complexType name="ProblemActionType" mixed="false">
+		<xs:sequence>
+			<xs:element ref="tns:Action" minOccurs="0"/>
+			<xs:element name="SoapAction" minOccurs="0" type="xs:anyURI"/>
+		</xs:sequence>
+		<xs:anyAttribute namespace="##other" processContents="lax"/>
+	</xs:complexType>
+	
+</xs:schema>

--- a/src/main/resources/xsd/xml.xsd
+++ b/src/main/resources/xsd/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>
+

--- a/src/test/java/org/metricshub/winrm/CatalogResolutionTest.java
+++ b/src/test/java/org/metricshub/winrm/CatalogResolutionTest.java
@@ -1,0 +1,51 @@
+package org.metricshub.winrm;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+import org.apache.cxf.catalog.OASISCatalogManager;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the JAX-WS catalog shipped at META-INF/jax-ws-catalog.xml is
+ * auto-discovered by Apache CXF and remaps the absolute schema URLs referenced
+ * by wsdl/WinRM.wsdl to local classpath resources.
+ *
+ * <p>Without this mapping the WSDL loader fetches dsp8033 / dsp8034 / xml.xsd /
+ * ws-addr.xsd from schemas.dmtf.org / www.w3.org over the network. On offline
+ * or restricted-egress hosts that fetch blocks for ~75 s (OS TCP timeout) and
+ * the connection attempt fails with
+ * {@code WSDLException(PARSER_ERROR) ... Caused by: ConnectException}.
+ */
+class CatalogResolutionTest {
+
+	@Test
+	void catalogResolvesWsdlImportUrlsToClasspathResources() throws Exception {
+		final Bus bus = BusFactory.getDefaultBus(true);
+		final OASISCatalogManager catalog = OASISCatalogManager.getCatalogManager(bus);
+		assertNotNull(catalog, "CXF OASISCatalogManager must be available");
+
+		assertResolvesToClasspath(catalog, "http://schemas.dmtf.org/wbem/wsman/1/dsp8033_1.0.xsd", "dsp8033_1.0.xsd");
+		assertResolvesToClasspath(catalog, "http://schemas.dmtf.org/wbem/wsman/1/dsp8034_1.0.xsd", "dsp8034_1.0.xsd");
+		assertResolvesToClasspath(catalog, "http://www.w3.org/2001/xml.xsd", "xml.xsd");
+		assertResolvesToClasspath(catalog, "http://www.w3.org/2006/03/addressing/ws-addr.xsd", "ws-addr.xsd");
+	}
+
+	private static void assertResolvesToClasspath(
+		final OASISCatalogManager catalog,
+		final String systemId,
+		final String expectedSuffix
+	) throws Exception {
+		final String resolved = catalog.resolveSystem(systemId);
+		assertNotNull(resolved, "catalog did not resolve " + systemId);
+		// Must NOT be a network URL — otherwise CXF will still hit the network at runtime.
+		assertFalse(
+			resolved.startsWith("http://") || resolved.startsWith("https://"),
+			"catalog returned a network URL for " + systemId + " -> " + resolved
+		);
+		assertTrue(resolved.endsWith(expectedSuffix), "resolved URI does not end with " + expectedSuffix + ": " + resolved);
+	}
+}

--- a/src/test/java/org/metricshub/winrm/CatalogResolutionTest.java
+++ b/src/test/java/org/metricshub/winrm/CatalogResolutionTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.InputStream;
+import java.net.URI;
 import org.apache.cxf.Bus;
 import org.apache.cxf.BusFactory;
 import org.apache.cxf.catalog.OASISCatalogManager;
@@ -24,14 +26,20 @@ class CatalogResolutionTest {
 
 	@Test
 	void catalogResolvesWsdlImportUrlsToClasspathResources() throws Exception {
-		final Bus bus = BusFactory.getDefaultBus(true);
-		final OASISCatalogManager catalog = OASISCatalogManager.getCatalogManager(bus);
-		assertNotNull(catalog, "CXF OASISCatalogManager must be available");
+		// Dedicated Bus so the test neither leaks CXF resources nor mutates the
+		// JVM-wide default Bus shared with other tests.
+		final Bus bus = BusFactory.newInstance().createBus();
+		try {
+			final OASISCatalogManager catalog = OASISCatalogManager.getCatalogManager(bus);
+			assertNotNull(catalog, "CXF OASISCatalogManager must be available");
 
-		assertResolvesToClasspath(catalog, "http://schemas.dmtf.org/wbem/wsman/1/dsp8033_1.0.xsd", "dsp8033_1.0.xsd");
-		assertResolvesToClasspath(catalog, "http://schemas.dmtf.org/wbem/wsman/1/dsp8034_1.0.xsd", "dsp8034_1.0.xsd");
-		assertResolvesToClasspath(catalog, "http://www.w3.org/2001/xml.xsd", "xml.xsd");
-		assertResolvesToClasspath(catalog, "http://www.w3.org/2006/03/addressing/ws-addr.xsd", "ws-addr.xsd");
+			assertResolvesToClasspath(catalog, "http://schemas.dmtf.org/wbem/wsman/1/dsp8033_1.0.xsd", "dsp8033_1.0.xsd");
+			assertResolvesToClasspath(catalog, "http://schemas.dmtf.org/wbem/wsman/1/dsp8034_1.0.xsd", "dsp8034_1.0.xsd");
+			assertResolvesToClasspath(catalog, "http://www.w3.org/2001/xml.xsd", "xml.xsd");
+			assertResolvesToClasspath(catalog, "http://www.w3.org/2006/03/addressing/ws-addr.xsd", "ws-addr.xsd");
+		} finally {
+			bus.shutdown(true);
+		}
 	}
 
 	private static void assertResolvesToClasspath(
@@ -47,5 +55,10 @@ class CatalogResolutionTest {
 			"catalog returned a network URL for " + systemId + " -> " + resolved
 		);
 		assertTrue(resolved.endsWith(expectedSuffix), "resolved URI does not end with " + expectedSuffix + ": " + resolved);
+		// The mapping must point at a resource that actually exists and is readable,
+		// not just a well-formed URI.
+		try (InputStream stream = new URI(resolved).toURL().openStream()) {
+			assertTrue(stream.read() != -1, "resolved URI is empty: " + resolved);
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #81.

`wsdl/WinRM.wsdl` declares three external `xs:import schemaLocation="http://..."` directives. Without a JAX-WS catalog, Apache CXF resolves them with `URL.openStream()` at every `WinRMService.createInstance(...)` call. On hosts that cannot reach `schemas.dmtf.org` / `www.w3.org`, the fetch blocks for ~75 s (OS TCP timeout) and `connect()` throws `WSDLException(PARSER_ERROR)` caused by `ConnectException: Connection timed out`. On hosts that can reach those domains, an outbound HTTP request happens every WinRM session — silent third-party dependency on DMTF / W3C servers.

This PR makes WSDL parsing fully self-contained.

## Changes

- **`src/main/resources/META-INF/jax-ws-catalog.xml`** *(new)* — OASIS XML catalog auto-discovered by CXF's `OASISCatalogManager`. Maps the four absolute URLs referenced (directly or transitively) by `WinRM.wsdl` to local classpath copies under `xsd/`:
  - `http://schemas.dmtf.org/wbem/wsman/1/dsp8033_1.0.xsd` → `../xsd/dsp8033_1.0.xsd`
  - `http://schemas.dmtf.org/wbem/wsman/1/dsp8034_1.0.xsd` → `../xsd/dsp8034_1.0.xsd`
  - `http://www.w3.org/2001/xml.xsd` → `../xsd/xml.xsd`
  - `http://www.w3.org/2006/03/addressing/ws-addr.xsd` → `../xsd/ws-addr.xsd`
- **`src/main/resources/xsd/dsp8034_1.0.xsd`** *(new, 7 135 bytes)* — WS-Management Addressing XML schema (DMTF DSP8034 v1.0.0, 2010-02-19). The WSDL's `<xs:import schemaLocation=".../dsp8034_1.0.xsd"/>` previously pointed at an absolute URL with no local fallback; the bundled `dsp8033_1.0.xsd` also imports this schema, so a network fetch was required even when dsp8033 resolved locally.
- **`src/main/resources/xsd/xml.xsd`** *(new, 8 836 bytes)* — W3C `xml` namespace schema, referenced by both the WSDL and the bundled `wsman.xsd`.
- **`src/main/resources/xsd/ws-addr.xsd`** *(new, 5 574 bytes)* — W3C WS-Addressing schema, transitively imported by `dsp8033_1.0.xsd` and `transfer.xsd`.
- **`src/test/java/org/metricshub/winrm/CatalogResolutionTest.java`** *(new)* — verifies CXF's `OASISCatalogManager` resolves each of the four `systemId`s to a non-network URI. Runs in <200 ms, no host required.

No Java source files are modified. No public API change.

## Why a catalog rather than fixing the WSDL?

Editing the WSDL to use relative `schemaLocation` values would also work, but:

- The WSDL's absolute URLs are the canonical references the schemas were authored against and match what other WS-Management implementations ship.
- A catalog is the standard JAX-WS solution to this class of problem and works without touching the codegen pipeline (`@WebServiceClient(wsdlLocation=...)`).
- A catalog is additive: existing consumers that happen to have working egress see no behavioural change beyond the fetch being skipped.

## Verification

`mvn test` — all 30 tests pass, including the new `CatalogResolutionTest`:

```
[INFO] Tests run: 30, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

End-to-end verification (separate downstream codebase that consumes this library): scans against a WinRM target on an offline host that previously failed with `WSDLException(PARSER_ERROR) … dsp8034_1.0.xsd … ConnectException` now succeed without any outbound traffic to `schemas.dmtf.org` or `www.w3.org`.

## Schema licensing

- DMTF DSP8033 / DSP8034 schemas are DMTF Standard documents — explicitly freely redistributable with attribution preserved in the file header.
- W3C `xml.xsd` and `ws-addr.xsd` are W3C Recommendations under the W3C Document License (BSD-style, attribution required); also explicitly intended for redistribution.

Each file retains its original copyright header.

## Test plan

- [x] `mvn test` passes on Linux and Windows
- [x] `prettier:check`, `checkstyle:check`, `pmd:check` pass (no formatting / style violations introduced)
- [x] New `CatalogResolutionTest` verifies catalog wiring without touching the network or requiring a WinRM host
- [x] Offline reproducer (block egress to `schemas.dmtf.org`) — previously failed in 75 s, now succeeds with WSDL fully parsed from classpath
