### PR TITLE
Fix the PMD violations reported by the Maven site (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,8 @@ unaffected. Consequences:
   WSMan namespace variants. WSMan fault exceptions additionally carry the detailed `WSManFault`
   message (including the provider-level detail, e.g. WMI `WBEM_E_*` mnemonics) alongside the SOAP
   reason text.
-- Code quality: the PMD report is clean (issue #122). The cleanup is behavior-preserving — redundant
+- Code quality: the PMD report is clean and `pmd:check` now runs in `mvn verify`, so a new violation
+  of `pmd.xml` fails the build (issue #122). The cleanup is behavior-preserving — redundant
   parentheses and modifiers removed, empty catch blocks named and commented, and two loops
   restructured. The only signature change is the removal of the unused `target` parameter from the
   `CipherGen` constructor (an internal NTLM helper).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,3 +97,7 @@ unaffected. Consequences:
   WSMan namespace variants. WSMan fault exceptions additionally carry the detailed `WSManFault`
   message (including the provider-level detail, e.g. WMI `WBEM_E_*` mnemonics) alongside the SOAP
   reason text.
+- Code quality: the PMD report is clean (issue #122). The cleanup is behavior-preserving — redundant
+  parentheses and modifiers removed, empty catch blocks named and commented, and two loops
+  restructured. The only signature change is the removal of the unused `target` parameter from the
+  `CipherGen` constructor (an internal NTLM helper).

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,31 @@
 				</executions>
 			</plugin>
 
+			<!--
+				pmd: fail the build on any violation of pmd.xml, so the PMD report stays clean.
+				Version pinned to the one the parent manages for the site report, so the gate and
+				the report always run the same PMD.
+			-->
+			<plugin>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>3.26.0</version>
+				<executions>
+					<execution>
+						<phase>verify</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<targetJdk>${maven.compiler.release}</targetJdk>
+					<rulesets>
+						<ruleset>pmd.xml</ruleset>
+					</rulesets>
+					<printFailingErrors>true</printFailingErrors>
+				</configuration>
+			</plugin>
+
 		</plugins>
 	</build>
 

--- a/src/main/java/org/metricshub/winrm/ShareRemoteDirectoryConsumer.java
+++ b/src/main/java/org/metricshub/winrm/ShareRemoteDirectoryConsumer.java
@@ -30,5 +30,5 @@ public interface ShareRemoteDirectoryConsumer<W extends WindowsRemoteExecutor, R
 	 * @param shareName The Share Name.
 	 * @param timeout Timeout in milliseconds.
 	 */
-	public void apply(final W windowsRemoteExecutor, final R remotePath, final S shareName, final T timeout);
+	void apply(final W windowsRemoteExecutor, final R remotePath, final S shareName, final T timeout);
 }

--- a/src/main/java/org/metricshub/winrm/ShellFileCopy.java
+++ b/src/main/java/org/metricshub/winrm/ShellFileCopy.java
@@ -637,11 +637,11 @@ public class ShellFileCopy {
 	static boolean isRetryableQuotaRejection(final Exception exception) {
 		final String message = exception.getMessage();
 
-		return (message != null
+		return message != null
 			&&
 			message.contains(FAULT_OPERATION_QUOTA)
 			&&
-			(message.contains("Command failed") || message.contains("Create shell failed")));
+			(message.contains("Command failed") || message.contains("Create shell failed"));
 	}
 
 	/**
@@ -810,6 +810,8 @@ public class ShellFileCopy {
 		}
 
 		/** Whether this remote digest matches the digest of the given local content. */
+		// PMD does not resolve the call through Optional<RemoteDigest>#get() and reports this as unused.
+		@SuppressWarnings("PMD.UnusedPrivateMethod")
 		private boolean matches(final byte[] content) {
 			return digestHex("SHA256".equals(algorithm) ? "SHA-256" : "SHA-1", content).equals(digest);
 		}

--- a/src/main/java/org/metricshub/winrm/WindowsRemoteExecutor.java
+++ b/src/main/java/org/metricshub/winrm/WindowsRemoteExecutor.java
@@ -41,7 +41,7 @@ public interface WindowsRemoteExecutor extends AutoCloseable {
 	 * @throws WqlQuerySyntaxException if WQL query syntax is invalid
 	 * @throws WindowsRemoteException For any problem encountered
 	 */
-	public List<Map<String, Object>> executeWql(final String wqlQuery, final long timeout)
+	List<Map<String, Object>> executeWql(final String wqlQuery, final long timeout)
 		throws TimeoutException, WqlQuerySyntaxException, WindowsRemoteException;
 
 	/**
@@ -55,7 +55,7 @@ public interface WindowsRemoteExecutor extends AutoCloseable {
 	 * @throws WindowsRemoteException For any problem encountered
 	 * @throws TimeoutException To notify userName of timeout.
 	 */
-	public WindowsRemoteCommandResult executeCommand(
+	WindowsRemoteCommandResult executeCommand(
 		final String command,
 		final String workingDirectory,
 		final Charset charset,
@@ -67,21 +67,21 @@ public interface WindowsRemoteExecutor extends AutoCloseable {
 	 *
 	 * @return
 	 */
-	public String getHostname();
+	String getHostname();
 
 	/**
 	 * Get the username.
 	 *
 	 * @return
 	 */
-	public String getUsername();
+	String getUsername();
 
 	/**
 	 * Get the password.
 	 *
 	 * @return
 	 */
-	public char[] getPassword();
+	char[] getPassword();
 
 	/**
 	 * Close the executor and release its resources. Narrows {@link AutoCloseable#close()} so it does
@@ -89,5 +89,5 @@ public interface WindowsRemoteExecutor extends AutoCloseable {
 	 * {@link Exception}.
 	 */
 	@Override
-	public void close();
+	void close();
 }

--- a/src/main/java/org/metricshub/winrm/WmiHelper.java
+++ b/src/main/java/org/metricshub/winrm/WmiHelper.java
@@ -74,7 +74,7 @@ public abstract class WmiHelper {
 	 */
 	public static boolean isLocalNetworkResource(final String networkResource) {
 		Utils.checkNonNull(networkResource, "networkResource");
-		return (!networkResource.startsWith("\\\\")
+		return !networkResource.startsWith("\\\\")
 			||
 			networkResource.startsWith("\\\\localhost\\")
 			||
@@ -86,7 +86,7 @@ public abstract class WmiHelper {
 			||
 			networkResource.startsWith("\\\\0000:0000:0000:0000:0000:0000:0000:0001\\")
 			||
-			networkResource.toLowerCase().startsWith("\\\\" + Utils.getComputerName().toLowerCase() + "\\"));
+			networkResource.toLowerCase().startsWith("\\\\" + Utils.getComputerName().toLowerCase() + "\\");
 	}
 
 	/**

--- a/src/main/java/org/metricshub/winrm/command/WinRMCommandExecutor.java
+++ b/src/main/java/org/metricshub/winrm/command/WinRMCommandExecutor.java
@@ -101,7 +101,7 @@ public class WinRMCommandExecutor {
 			: localFileToCopyList.stream().filter(Utils::isNotBlank).collect(Collectors.toList());
 
 		try (
-			final WindowsRemoteExecutor winRMService = WinRMExecutorFactory.createInstance(
+			WindowsRemoteExecutor winRMService = WinRMExecutorFactory.createInstance(
 				winRMEndpoint,
 				timeout,
 				ticketCache,

--- a/src/main/java/org/metricshub/winrm/light/ByteArrayUtils.java
+++ b/src/main/java/org/metricshub/winrm/light/ByteArrayUtils.java
@@ -92,7 +92,7 @@ public class ByteArrayUtils {
 	}
 
 	public static byte[] concat(final byte[]... sequences) {
-		try (final ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
 			for (byte[] s : sequences) {
 				out.write(s);
 			}

--- a/src/main/java/org/metricshub/winrm/light/CipherGen.java
+++ b/src/main/java/org/metricshub/winrm/light/CipherGen.java
@@ -75,7 +75,6 @@ public class CipherGen {
 		final String user,
 		final String password,
 		final byte[] challenge,
-		final String target,
 		final byte[] targetInformation
 	) {
 		this.random = random;

--- a/src/main/java/org/metricshub/winrm/light/Envelopes.java
+++ b/src/main/java/org/metricshub/winrm/light/Envelopes.java
@@ -59,7 +59,7 @@ final class Envelopes {
 	// --- WQL ---------------------------------------------------------------
 
 	static String enumerateWql(final String url, final String namespace, final String wql, final long timeoutMs) {
-		return (envelopeOpen(false) +
+		return envelopeOpen(false) +
 			header(url, wmiResourceUri(namespace), ACTION_ENUMERATE, timeoutMs, null, null) +
 			"<s:Body><wsen:Enumerate>" +
 			"<wsman:OptimizeEnumeration/>" +
@@ -67,18 +67,18 @@ final class Envelopes {
 			"<wsman:Filter Dialect=\"http://schemas.microsoft.com/wbem/wsman/1/WQL\">" +
 			escape(wql) +
 			"</wsman:Filter>" +
-			"</wsen:Enumerate></s:Body></s:Envelope>");
+			"</wsen:Enumerate></s:Body></s:Envelope>";
 	}
 
 	static String pull(final String url, final String namespace, final String context, final long timeoutMs) {
-		return (envelopeOpen(false) +
+		return envelopeOpen(false) +
 			header(url, wmiResourceUri(namespace), ACTION_PULL, timeoutMs, null, null) +
 			"<s:Body><wsen:Pull>" +
 			"<wsen:EnumerationContext>" +
 			escape(context) +
 			"</wsen:EnumerationContext>" +
 			"<wsen:MaxElements>32000</wsen:MaxElements>" +
-			"</wsen:Pull></s:Body></s:Envelope>");
+			"</wsen:Pull></s:Body></s:Envelope>";
 	}
 
 	// --- Command shell -----------------------------------------------------
@@ -91,13 +91,13 @@ final class Envelopes {
 		final String workingDir = (workingDirectory == null || workingDirectory.trim().isEmpty())
 			? ""
 			: "<rsp:WorkingDirectory>" + escape(workingDirectory) + "</rsp:WorkingDirectory>";
-		return (envelopeOpen(true) +
+		return envelopeOpen(true) +
 			header(url, SHELL_RESOURCE_URI, ACTION_CREATE, timeoutMs, null, optionSet) +
 			"<s:Body><rsp:Shell>" +
 			"<rsp:InputStreams>stdin</rsp:InputStreams>" +
 			"<rsp:OutputStreams>stdout stderr</rsp:OutputStreams>" +
 			workingDir +
-			"</rsp:Shell></s:Body></s:Envelope>");
+			"</rsp:Shell></s:Body></s:Envelope>";
 	}
 
 	static String command(final String url, final String shellId, final String commandLine, final long timeoutMs) {
@@ -105,35 +105,35 @@ final class Envelopes {
 			"<wsman:Option Name=\"WINRS_CONSOLEMODE_STDIN\">TRUE</wsman:Option>" +
 			"<wsman:Option Name=\"WINRS_SKIP_CMD_SHELL\">FALSE</wsman:Option>" +
 			"</wsman:OptionSet>";
-		return (envelopeOpen(true) +
+		return envelopeOpen(true) +
 			header(url, SHELL_RESOURCE_URI, ACTION_COMMAND, timeoutMs, shellSelector(shellId), optionSet) +
 			"<s:Body><rsp:CommandLine><rsp:Command>" +
 			escape(commandLine) +
-			"</rsp:Command></rsp:CommandLine></s:Body></s:Envelope>");
+			"</rsp:Command></rsp:CommandLine></s:Body></s:Envelope>";
 	}
 
 	static String receive(final String url, final String shellId, final String commandId, final long timeoutMs) {
-		return (envelopeOpen(true) +
+		return envelopeOpen(true) +
 			header(url, SHELL_RESOURCE_URI, ACTION_RECEIVE, timeoutMs, shellSelector(shellId), null) +
 			"<s:Body><rsp:Receive><rsp:DesiredStream CommandId=\"" +
 			escape(commandId) +
-			"\">stdout stderr</rsp:DesiredStream></rsp:Receive></s:Body></s:Envelope>");
+			"\">stdout stderr</rsp:DesiredStream></rsp:Receive></s:Body></s:Envelope>";
 	}
 
 	static String signal(final String url, final String shellId, final String commandId, final long timeoutMs) {
-		return (envelopeOpen(true) +
+		return envelopeOpen(true) +
 			header(url, SHELL_RESOURCE_URI, ACTION_SIGNAL, timeoutMs, shellSelector(shellId), null) +
 			"<s:Body><rsp:Signal CommandId=\"" +
 			escape(commandId) +
 			"\"><rsp:Code>" +
 			TERMINATE_CODE +
-			"</rsp:Code></rsp:Signal></s:Body></s:Envelope>");
+			"</rsp:Code></rsp:Signal></s:Body></s:Envelope>";
 	}
 
 	static String deleteShell(final String url, final String shellId, final long timeoutMs) {
-		return (envelopeOpen(true) +
+		return envelopeOpen(true) +
 			header(url, SHELL_RESOURCE_URI, ACTION_DELETE, timeoutMs, shellSelector(shellId), null) +
-			"<s:Body/></s:Envelope>");
+			"<s:Body/></s:Envelope>";
 	}
 
 	// --- helpers -----------------------------------------------------------
@@ -143,8 +143,8 @@ final class Envelopes {
 	}
 
 	private static String shellSelector(final String shellId) {
-		return ("<wsman:SelectorSet><wsman:Selector Name=\"ShellId\">" + escape(shellId)
-			+ "</wsman:Selector></wsman:SelectorSet>");
+		return "<wsman:SelectorSet><wsman:Selector Name=\"ShellId\">" + escape(shellId)
+			+ "</wsman:Selector></wsman:SelectorSet>";
 	}
 
 	/**
@@ -165,7 +165,7 @@ final class Envelopes {
 		final String selectorSet,
 		final String optionSet
 	) {
-		return ("<s:Header>" +
+		return "<s:Header>" +
 			"<wsa:To>" +
 			url +
 			"</wsa:To>" +
@@ -190,11 +190,11 @@ final class Envelopes {
 			"<wsman:OperationTimeout>" +
 			operationTimeout(timeoutMs) +
 			"</wsman:OperationTimeout>" +
-			"</s:Header>");
+			"</s:Header>";
 	}
 
 	private static String envelopeOpen(final boolean shell) {
-		return ("<s:Envelope xmlns:s=\"" +
+		return "<s:Envelope xmlns:s=\"" +
 			SOAP +
 			"\" xmlns:wsa=\"" +
 			WSA +
@@ -204,7 +204,7 @@ final class Envelopes {
 			WSEN +
 			"\"" +
 			(shell ? " xmlns:rsp=\"" + RSP + "\"" : "") +
-			">");
+			">";
 	}
 
 	private static String escape(final String s) {

--- a/src/main/java/org/metricshub/winrm/light/HttpTransport.java
+++ b/src/main/java/org/metricshub/winrm/light/HttpTransport.java
@@ -178,7 +178,7 @@ final class HttpTransport implements AutoCloseable {
 		} finally {
 			try {
 				socket.setSoTimeout(previousTimeout);
-			} catch (final IOException ignore) {
+			} catch (final IOException ignored) {
 				// socket is being discarded on the stale path anyway
 			}
 		}
@@ -218,7 +218,7 @@ final class HttpTransport implements AutoCloseable {
 			// cannot leak the freshly created SSLSocket.
 			try {
 				newSocket.close();
-			} catch (final IOException ignore) {
+			} catch (final IOException ignored) {
 				// best effort
 			}
 			socket = null;
@@ -355,9 +355,10 @@ final class HttpTransport implements AutoCloseable {
 			if (size == 0) {
 				// After the terminating chunk come zero or more optional trailer fields, then a final
 				// empty line. Consume them all, or leftover bytes desync the kept-alive NTLM socket.
-				String trailer;
-				while ((trailer = readLine()) != null && !trailer.isEmpty()) {
-					// discard trailer field
+				String trailer = readLine();
+				while (trailer != null && !trailer.isEmpty()) {
+					// discard the trailer field and look at the next line
+					trailer = readLine();
 				}
 				break;
 			}
@@ -379,7 +380,7 @@ final class HttpTransport implements AutoCloseable {
 		if (doomed != null) {
 			try {
 				doomed.close();
-			} catch (final IOException ignore) {
+			} catch (final IOException ignored) {
 				// best effort
 			}
 		}

--- a/src/main/java/org/metricshub/winrm/light/KerberosAuthScheme.java
+++ b/src/main/java/org/metricshub/winrm/light/KerberosAuthScheme.java
@@ -120,7 +120,7 @@ final class KerberosAuthScheme implements AuthScheme {
 		if (context != null) {
 			try {
 				context.dispose();
-			} catch (final GSSException ignore) {
+			} catch (final GSSException ignored) {
 				// disposing a dead context is best-effort
 			}
 			context = null;

--- a/src/main/java/org/metricshub/winrm/light/MD4.java
+++ b/src/main/java/org/metricshub/winrm/light/MD4.java
@@ -126,84 +126,84 @@ public class MD4 {
 	}
 
 	private void round1(final int[] d) {
-		a = rotintlft((a + f(b, c, this.d) + d[0]), 3);
-		this.d = rotintlft((this.d + f(a, b, c) + d[1]), 7);
-		c = rotintlft((c + f(this.d, a, b) + d[2]), 11);
-		b = rotintlft((b + f(c, this.d, a) + d[3]), 19);
+		a = rotintlft(a + f(b, c, this.d) + d[0], 3);
+		this.d = rotintlft(this.d + f(a, b, c) + d[1], 7);
+		c = rotintlft(c + f(this.d, a, b) + d[2], 11);
+		b = rotintlft(b + f(c, this.d, a) + d[3], 19);
 
-		a = rotintlft((a + f(b, c, this.d) + d[4]), 3);
-		this.d = rotintlft((this.d + f(a, b, c) + d[5]), 7);
-		c = rotintlft((c + f(this.d, a, b) + d[6]), 11);
-		b = rotintlft((b + f(c, this.d, a) + d[7]), 19);
+		a = rotintlft(a + f(b, c, this.d) + d[4], 3);
+		this.d = rotintlft(this.d + f(a, b, c) + d[5], 7);
+		c = rotintlft(c + f(this.d, a, b) + d[6], 11);
+		b = rotintlft(b + f(c, this.d, a) + d[7], 19);
 
-		a = rotintlft((a + f(b, c, this.d) + d[8]), 3);
-		this.d = rotintlft((this.d + f(a, b, c) + d[9]), 7);
-		c = rotintlft((c + f(this.d, a, b) + d[10]), 11);
-		b = rotintlft((b + f(c, this.d, a) + d[11]), 19);
+		a = rotintlft(a + f(b, c, this.d) + d[8], 3);
+		this.d = rotintlft(this.d + f(a, b, c) + d[9], 7);
+		c = rotintlft(c + f(this.d, a, b) + d[10], 11);
+		b = rotintlft(b + f(c, this.d, a) + d[11], 19);
 
-		a = rotintlft((a + f(b, c, this.d) + d[12]), 3);
-		this.d = rotintlft((this.d + f(a, b, c) + d[13]), 7);
-		c = rotintlft((c + f(this.d, a, b) + d[14]), 11);
-		b = rotintlft((b + f(c, this.d, a) + d[15]), 19);
+		a = rotintlft(a + f(b, c, this.d) + d[12], 3);
+		this.d = rotintlft(this.d + f(a, b, c) + d[13], 7);
+		c = rotintlft(c + f(this.d, a, b) + d[14], 11);
+		b = rotintlft(b + f(c, this.d, a) + d[15], 19);
 	}
 
 	private void round2(final int[] d) {
-		a = rotintlft((a + g(b, c, this.d) + d[0] + 0x5a827999), 3);
-		this.d = rotintlft((this.d + g(a, b, c) + d[4] + 0x5a827999), 5);
-		c = rotintlft((c + g(this.d, a, b) + d[8] + 0x5a827999), 9);
-		b = rotintlft((b + g(c, this.d, a) + d[12] + 0x5a827999), 13);
+		a = rotintlft(a + g(b, c, this.d) + d[0] + 0x5a827999, 3);
+		this.d = rotintlft(this.d + g(a, b, c) + d[4] + 0x5a827999, 5);
+		c = rotintlft(c + g(this.d, a, b) + d[8] + 0x5a827999, 9);
+		b = rotintlft(b + g(c, this.d, a) + d[12] + 0x5a827999, 13);
 
-		a = rotintlft((a + g(b, c, this.d) + d[1] + 0x5a827999), 3);
-		this.d = rotintlft((this.d + g(a, b, c) + d[5] + 0x5a827999), 5);
-		c = rotintlft((c + g(this.d, a, b) + d[9] + 0x5a827999), 9);
-		b = rotintlft((b + g(c, this.d, a) + d[13] + 0x5a827999), 13);
+		a = rotintlft(a + g(b, c, this.d) + d[1] + 0x5a827999, 3);
+		this.d = rotintlft(this.d + g(a, b, c) + d[5] + 0x5a827999, 5);
+		c = rotintlft(c + g(this.d, a, b) + d[9] + 0x5a827999, 9);
+		b = rotintlft(b + g(c, this.d, a) + d[13] + 0x5a827999, 13);
 
-		a = rotintlft((a + g(b, c, this.d) + d[2] + 0x5a827999), 3);
-		this.d = rotintlft((this.d + g(a, b, c) + d[6] + 0x5a827999), 5);
-		c = rotintlft((c + g(this.d, a, b) + d[10] + 0x5a827999), 9);
-		b = rotintlft((b + g(c, this.d, a) + d[14] + 0x5a827999), 13);
+		a = rotintlft(a + g(b, c, this.d) + d[2] + 0x5a827999, 3);
+		this.d = rotintlft(this.d + g(a, b, c) + d[6] + 0x5a827999, 5);
+		c = rotintlft(c + g(this.d, a, b) + d[10] + 0x5a827999, 9);
+		b = rotintlft(b + g(c, this.d, a) + d[14] + 0x5a827999, 13);
 
-		a = rotintlft((a + g(b, c, this.d) + d[3] + 0x5a827999), 3);
-		this.d = rotintlft((this.d + g(a, b, c) + d[7] + 0x5a827999), 5);
-		c = rotintlft((c + g(this.d, a, b) + d[11] + 0x5a827999), 9);
-		b = rotintlft((b + g(c, this.d, a) + d[15] + 0x5a827999), 13);
+		a = rotintlft(a + g(b, c, this.d) + d[3] + 0x5a827999, 3);
+		this.d = rotintlft(this.d + g(a, b, c) + d[7] + 0x5a827999, 5);
+		c = rotintlft(c + g(this.d, a, b) + d[11] + 0x5a827999, 9);
+		b = rotintlft(b + g(c, this.d, a) + d[15] + 0x5a827999, 13);
 	}
 
 	private void round3(final int[] d) {
-		a = rotintlft((a + h(b, c, this.d) + d[0] + 0x6ed9eba1), 3);
-		this.d = rotintlft((this.d + h(a, b, c) + d[8] + 0x6ed9eba1), 9);
-		c = rotintlft((c + h(this.d, a, b) + d[4] + 0x6ed9eba1), 11);
-		b = rotintlft((b + h(c, this.d, a) + d[12] + 0x6ed9eba1), 15);
+		a = rotintlft(a + h(b, c, this.d) + d[0] + 0x6ed9eba1, 3);
+		this.d = rotintlft(this.d + h(a, b, c) + d[8] + 0x6ed9eba1, 9);
+		c = rotintlft(c + h(this.d, a, b) + d[4] + 0x6ed9eba1, 11);
+		b = rotintlft(b + h(c, this.d, a) + d[12] + 0x6ed9eba1, 15);
 
-		a = rotintlft((a + h(b, c, this.d) + d[2] + 0x6ed9eba1), 3);
-		this.d = rotintlft((this.d + h(a, b, c) + d[10] + 0x6ed9eba1), 9);
-		c = rotintlft((c + h(this.d, a, b) + d[6] + 0x6ed9eba1), 11);
-		b = rotintlft((b + h(c, this.d, a) + d[14] + 0x6ed9eba1), 15);
+		a = rotintlft(a + h(b, c, this.d) + d[2] + 0x6ed9eba1, 3);
+		this.d = rotintlft(this.d + h(a, b, c) + d[10] + 0x6ed9eba1, 9);
+		c = rotintlft(c + h(this.d, a, b) + d[6] + 0x6ed9eba1, 11);
+		b = rotintlft(b + h(c, this.d, a) + d[14] + 0x6ed9eba1, 15);
 
-		a = rotintlft((a + h(b, c, this.d) + d[1] + 0x6ed9eba1), 3);
-		this.d = rotintlft((this.d + h(a, b, c) + d[9] + 0x6ed9eba1), 9);
-		c = rotintlft((c + h(this.d, a, b) + d[5] + 0x6ed9eba1), 11);
-		b = rotintlft((b + h(c, this.d, a) + d[13] + 0x6ed9eba1), 15);
+		a = rotintlft(a + h(b, c, this.d) + d[1] + 0x6ed9eba1, 3);
+		this.d = rotintlft(this.d + h(a, b, c) + d[9] + 0x6ed9eba1, 9);
+		c = rotintlft(c + h(this.d, a, b) + d[5] + 0x6ed9eba1, 11);
+		b = rotintlft(b + h(c, this.d, a) + d[13] + 0x6ed9eba1, 15);
 
-		a = rotintlft((a + h(b, c, this.d) + d[3] + 0x6ed9eba1), 3);
-		this.d = rotintlft((this.d + h(a, b, c) + d[11] + 0x6ed9eba1), 9);
-		c = rotintlft((c + h(this.d, a, b) + d[7] + 0x6ed9eba1), 11);
-		b = rotintlft((b + h(c, this.d, a) + d[15] + 0x6ed9eba1), 15);
+		a = rotintlft(a + h(b, c, this.d) + d[3] + 0x6ed9eba1, 3);
+		this.d = rotintlft(this.d + h(a, b, c) + d[11] + 0x6ed9eba1, 9);
+		c = rotintlft(c + h(this.d, a, b) + d[7] + 0x6ed9eba1, 11);
+		b = rotintlft(b + h(c, this.d, a) + d[15] + 0x6ed9eba1, 15);
 	}
 
 	private static int f(final int x, final int y, final int z) {
-		return ((x & y) | (~x & z));
+		return (x & y) | (~x & z);
 	}
 
 	private static int g(final int x, final int y, final int z) {
-		return ((x & y) | (x & z) | (y & z));
+		return (x & y) | (x & z) | (y & z);
 	}
 
 	private static int h(final int x, final int y, final int z) {
-		return (x ^ y ^ z);
+		return x ^ y ^ z;
 	}
 
 	private static int rotintlft(final int val, final int numbits) {
-		return ((val << numbits) | (val >>> (32 - numbits)));
+		return (val << numbits) | (val >>> (32 - numbits));
 	}
 }

--- a/src/main/java/org/metricshub/winrm/light/NTLMMessage.java
+++ b/src/main/java/org/metricshub/winrm/light/NTLMMessage.java
@@ -82,13 +82,13 @@ class NTLMMessage {
 		if (src.length < index + 4) {
 			return 0;
 		}
-		return ((src[index] & 0xff)
+		return (src[index] & 0xff)
 			|
 			((src[index + 1] & 0xff) << 8)
 			|
 			((src[index + 2] & 0xff) << 16)
 			|
-			((src[index + 3] & 0xff) << 24));
+			((src[index + 3] & 0xff) << 24);
 	}
 
 	/**

--- a/src/main/java/org/metricshub/winrm/light/NtlmCrypto.java
+++ b/src/main/java/org/metricshub/winrm/light/NtlmCrypto.java
@@ -41,7 +41,7 @@ final class NtlmCrypto {
 	private NtlmCrypto() {}
 
 	static byte[] encryptAndSign(final WinRMSession session, final byte[] messageBody) {
-		try (final ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
 			out.write(BOUNDARY_CR.getBytes(StandardCharsets.US_ASCII));
 			out.write("\tContent-Type: application/HTTP-SPNEGO-session-encrypted\r\n".getBytes(StandardCharsets.US_ASCII));
 			out.write(
@@ -181,19 +181,26 @@ final class NtlmCrypto {
 		void skipUntil(final String s) {
 			final byte[] expected = s.getBytes(StandardCharsets.US_ASCII);
 			int next = index;
-			outer: while (true) {
-				for (int i = 0; i < expected.length; i++) {
-					if (next + i >= bytes.length) {
-						throw new IllegalStateException("Encrypted-response framing terminated early looking for delimiter");
-					}
-					if (expected[i] != bytes[next + i]) {
-						next++;
-						continue outer;
-					}
-				}
-				index = next + expected.length;
-				return;
+			while (!matchesAt(next, expected)) {
+				next++;
 			}
+			index = next + expected.length;
+		}
+
+		/**
+		 * Whether {@code expected} occurs at the given offset, throwing when the remaining bytes are
+		 * too few to hold it — i.e. the delimiter is missing from the response altogether.
+		 */
+		private boolean matchesAt(final int offset, final byte[] expected) {
+			for (int i = 0; i < expected.length; i++) {
+				if (offset + i >= bytes.length) {
+					throw new IllegalStateException("Encrypted-response framing terminated early looking for delimiter");
+				}
+				if (expected[i] != bytes[offset + i]) {
+					return false;
+				}
+			}
+			return true;
 		}
 	}
 }

--- a/src/main/java/org/metricshub/winrm/light/Type1Message.java
+++ b/src/main/java/org/metricshub/winrm/light/Type1Message.java
@@ -50,8 +50,8 @@ class Type1Message extends NTLMMessage {
 	}
 
 	static int getDefaultFlags() {
-		return ( // Required flags
-		NTLMEngineUtils.FLAG_REQUEST_NTLM_V1
+		// Required flags
+		return NTLMEngineUtils.FLAG_REQUEST_NTLM_V1
 			|
 			NTLMEngineUtils.FLAG_REQUEST_NTLM2_SESSION
 			|
@@ -63,7 +63,7 @@ class Type1Message extends NTLMMessage {
 			|
 			NTLMEngineUtils.FLAG_REQUEST_56BIT_ENCRYPTION
 			|
-			NTLMEngineUtils.FLAG_REQUEST_UNICODE_ENCODING);
+			NTLMEngineUtils.FLAG_REQUEST_UNICODE_ENCODING;
 	}
 
 	/**

--- a/src/main/java/org/metricshub/winrm/light/Type3Message.java
+++ b/src/main/java/org/metricshub/winrm/light/Type3Message.java
@@ -39,7 +39,10 @@ public class Type3Message extends NTLMMessage {
 		java.security.SecureRandom rnd = null;
 		try {
 			rnd = java.security.SecureRandom.getInstance("SHA1PRNG");
-		} catch (final Exception ignore) {}
+		} catch (final Exception ignored) {
+			// SHA1PRNG is not guaranteed to be present: leave RND_GEN null and let the constructor
+			// reject the authentication attempt with a clear NtlmException.
+		}
 		RND_GEN = rnd;
 	}
 
@@ -93,7 +96,6 @@ public class Type3Message extends NTLMMessage {
 			user,
 			password,
 			nonce,
-			target,
 			responseTargetInformation
 		);
 

--- a/src/main/java/org/metricshub/winrm/light/WsmanClient.java
+++ b/src/main/java/org/metricshub/winrm/light/WsmanClient.java
@@ -261,7 +261,9 @@ final class WsmanClient implements AutoCloseable {
 			auth.reset();
 		}
 		final byte[] body = soap.getBytes(StandardCharsets.UTF_8);
-		while (true) {
+		// Stays null while the loop retries the next authentication scheme on a fresh connection.
+		Decoded decoded = null;
+		while (decoded == null) {
 			if (!auth.isAuthenticated()) {
 				pendingAuthorization = auth.authenticate(transport);
 			}
@@ -301,8 +303,9 @@ final class WsmanClient implements AutoCloseable {
 			if (resp.status != 200 && resp.status != 500) {
 				throw new IllegalStateException("WSMan request failed: HTTP " + resp.status);
 			}
-			return new Decoded(resp.status, parse(auth.unwrap(resp)));
+			decoded = new Decoded(resp.status, parse(auth.unwrap(resp)));
 		}
+		return decoded;
 	}
 
 	// --- XML helpers --------------------------------------------------------
@@ -350,9 +353,9 @@ final class WsmanClient implements AutoCloseable {
 	 * backend does.
 	 */
 	static boolean hasEnumerationElement(final Document doc, final String localName) {
-		return (doc.getElementsByTagNameNS(WS_ENUMERATION_NS, localName).getLength() > 0
+		return doc.getElementsByTagNameNS(WS_ENUMERATION_NS, localName).getLength() > 0
 			||
-			doc.getElementsByTagNameNS(WSMAN_NS, localName).getLength() > 0);
+			doc.getElementsByTagNameNS(WSMAN_NS, localName).getLength() > 0;
 	}
 
 	/** First text content of an element matched by both namespace and local name. */
@@ -365,11 +368,11 @@ final class WsmanClient implements AutoCloseable {
 		// The Items wrapper comes in the WS-Enumeration namespace (EnumerateResponse) or the WSMan
 		// namespace (PullResponse) depending on the operation; accept both, like the CXF backend, and
 		// nothing else — a WMI property or class named "Items" must not be mistaken for the wrapper.
-		collectItems(doc.getElementsByTagNameNS(WS_ENUMERATION_NS, "Items"), rows);
-		collectItems(doc.getElementsByTagNameNS(WSMAN_NS, "Items"), rows);
+		collectRows(doc.getElementsByTagNameNS(WS_ENUMERATION_NS, "Items"), rows);
+		collectRows(doc.getElementsByTagNameNS(WSMAN_NS, "Items"), rows);
 	}
 
-	private static void collectItems(final NodeList items, final List<Map<String, String>> rows) {
+	private static void collectRows(final NodeList items, final List<Map<String, String>> rows) {
 		for (int i = 0; i < items.getLength(); i++) {
 			final NodeList instances = items.item(i).getChildNodes();
 			for (int j = 0; j < instances.getLength(); j++) {
@@ -494,7 +497,7 @@ final class WsmanClient implements AutoCloseable {
 				if (shell != null) {
 					try {
 						request(Envelopes.deleteShell(url, shell, timeoutMs));
-					} catch (final Exception ignore) {
+					} catch (final Exception ignored) {
 						// best-effort shell cleanup
 					}
 				}

--- a/src/main/java/org/metricshub/winrm/service/WinRMEndpoint.java
+++ b/src/main/java/org/metricshub/winrm/service/WinRMEndpoint.java
@@ -220,13 +220,13 @@ public class WinRMEndpoint {
 			return false;
 		}
 		final WinRMEndpoint other = (WinRMEndpoint) obj;
-		return (Objects.equals(endpoint, other.endpoint)
+		return Objects.equals(endpoint, other.endpoint)
 			&&
 			Objects.equals(namespace, other.namespace)
 			&&
 			Arrays.equals(password, other.password)
 			&&
-			Objects.equals(rawUsername, other.rawUsername));
+			Objects.equals(rawUsername, other.rawUsername);
 	}
 
 	@Override

--- a/src/main/java/org/metricshub/winrm/wql/WinRMWqlExecutor.java
+++ b/src/main/java/org/metricshub/winrm/wql/WinRMWqlExecutor.java
@@ -120,7 +120,7 @@ public class WinRMWqlExecutor {
 		final WinRMEndpoint winRMEndpoint = new WinRMEndpoint(protocol, hostname, port, username, password, namespace);
 
 		try (
-			final WindowsRemoteExecutor winRMService = WinRMExecutorFactory.createInstance(
+			WindowsRemoteExecutor winRMService = WinRMExecutorFactory.createInstance(
 				winRMEndpoint,
 				timeout,
 				ticketCache,

--- a/src/test/java/org/metricshub/winrm/light/FakeWsmanServer.java
+++ b/src/test/java/org/metricshub/winrm/light/FakeWsmanServer.java
@@ -81,6 +81,7 @@ final class FakeWsmanServer implements AutoCloseable {
 	private final Deque<Scripted> script = new ArrayDeque<>();
 	private final List<String> decryptedRequests = new CopyOnWriteArrayList<>();
 	private volatile boolean closed;
+	private volatile boolean chunkedResponses;
 
 	FakeWsmanServer(final String domain, final String user, final String password) throws IOException {
 		this.expectedDomain = domain.toUpperCase(Locale.ROOT);
@@ -101,6 +102,17 @@ final class FakeWsmanServer implements AutoCloseable {
 		synchronized (script) {
 			script.addLast(new Scripted(status, soapBody));
 		}
+		return this;
+	}
+
+	/**
+	 * Serve the scripted bodies with {@code Transfer-Encoding: chunked} — several chunks, a chunk
+	 * extension, and trailer fields after the terminating chunk — instead of {@code Content-Length},
+	 * like a real WinRM host does. A client that mis-reads the framing (e.g. leaves the trailers in
+	 * the socket) desyncs the kept-alive connection and fails on the NEXT request.
+	 */
+	FakeWsmanServer withChunkedResponses() {
+		chunkedResponses = true;
 		return this;
 	}
 
@@ -334,7 +346,7 @@ final class FakeWsmanServer implements AutoCloseable {
 
 	// --- minimal HTTP -----------------------------------------------------------
 
-	private static void respond(
+	private void respond(
 		final OutputStream out,
 		final int status,
 		final String extraHeader,
@@ -342,6 +354,7 @@ final class FakeWsmanServer implements AutoCloseable {
 		final byte[] body
 	) throws IOException {
 		final byte[] payload = body == null ? new byte[0] : body;
+		final boolean chunked = chunkedResponses && payload.length > 0;
 		final StringBuilder head = new StringBuilder();
 		head.append("HTTP/1.1 ").append(status).append(' ').append(status == 200 ? "OK" : "Error").append("\r\n");
 		head.append("Server: FakeWsmanServer\r\n");
@@ -351,11 +364,37 @@ final class FakeWsmanServer implements AutoCloseable {
 		if (contentType != null) {
 			head.append("Content-Type: ").append(contentType).append("\r\n");
 		}
-		head.append("Content-Length: ").append(payload.length).append("\r\n");
+		head.append(chunked ? "Transfer-Encoding: chunked\r\n" : "Content-Length: " + payload.length + "\r\n");
 		head.append("\r\n");
 		out.write(head.toString().getBytes(StandardCharsets.ISO_8859_1));
-		out.write(payload);
+		if (chunked) {
+			writeChunkedBody(out, payload);
+		} else {
+			out.write(payload);
+		}
 		out.flush();
+	}
+
+	/** Write the payload as two chunks (the first with a chunk extension) plus a trailer field. */
+	private static void writeChunkedBody(final OutputStream out, final byte[] payload) throws IOException {
+		final int split = Math.max(1, payload.length / 2);
+		writeChunk(out, payload, 0, split, ";boundary=middle");
+		if (split < payload.length) {
+			writeChunk(out, payload, split, payload.length - split, "");
+		}
+		out.write("0\r\nX-Fake-Trailer: done\r\n\r\n".getBytes(StandardCharsets.ISO_8859_1));
+	}
+
+	private static void writeChunk(
+		final OutputStream out,
+		final byte[] payload,
+		final int offset,
+		final int length,
+		final String extension
+	) throws IOException {
+		out.write((Integer.toHexString(length) + extension + "\r\n").getBytes(StandardCharsets.ISO_8859_1));
+		out.write(payload, offset, length);
+		out.write("\r\n".getBytes(StandardCharsets.ISO_8859_1));
 	}
 
 	/** One parsed HTTP request: headers (lower-cased names) and the raw body. */

--- a/src/test/java/org/metricshub/winrm/light/WsmanProtocolTest.java
+++ b/src/test/java/org/metricshub/winrm/light/WsmanProtocolTest.java
@@ -132,6 +132,58 @@ class WsmanProtocolTest {
 		assertTrue(requests.get(2).contains("uuid:CTX-2"), requests.get(2));
 	}
 
+	@Test
+	void wqlPagesOverChunkedResponsesWithTrailers() throws Exception {
+		// Real WinRM hosts answer with Transfer-Encoding: chunked. The client must reassemble the
+		// chunks AND consume the trailer fields that follow the terminating chunk — leftover trailer
+		// bytes desync the kept-alive NTLM connection, so the SECOND request on it is what fails.
+		server
+			.withChunkedResponses()
+			.enqueue(
+				200,
+				envelope(
+					"<wsen:EnumerateResponse xmlns:wsen=\"" +
+						WSEN +
+						"\" xmlns:wsman=\"" +
+						WSMAN +
+						"\">" +
+						"<wsen:EnumerationContext>uuid:CTX-1</wsen:EnumerationContext>" +
+						"<wsman:Items>" +
+						service("Spooler", "Running") +
+						"</wsman:Items>" +
+						"</wsen:EnumerateResponse>"
+				)
+			)
+			.enqueue(
+				200,
+				envelope(
+					"<wsen:PullResponse xmlns:wsen=\"" +
+						WSEN +
+						"\" xmlns:wsman=\"" +
+						WSMAN +
+						"\">" +
+						"<wsman:Items>" +
+						service("WinRM", "Running") +
+						"</wsman:Items>" +
+						"<wsman:EndOfSequence/>" +
+						"</wsen:PullResponse>"
+				)
+			);
+
+		try (LightWinRMService service = client(PASSWORD)) {
+			final List<Map<String, Object>> rows = service.executeWql("SELECT Name,State FROM Win32_Service", TIMEOUT);
+
+			assertEquals(2, rows.size());
+			assertEquals("Spooler", rows.get(0).get("Name"));
+			assertEquals("WinRM", rows.get(1).get("Name"));
+		}
+
+		// The Pull was answered on the same connection: proof the trailers were fully drained.
+		final List<String> requests = server.decryptedRequests();
+		assertEquals(2, requests.size(), () -> String.join("\n---\n", requests));
+		assertTrue(requests.get(1).contains("uuid:CTX-1"), requests.get(1));
+	}
+
 	// --- Command shell lifecycle ------------------------------------------------
 
 	@Test


### PR DESCRIPTION
Closes #122.

The PMD report is now clean: **0 violations** (PMD 7.7.0, ruleset `pmd.xml`), down from 89 in the issue (91 on my checkout — see the note on `UnusedPrivateMethod` below).

## Breakdown

| Count | Rule | Fix |
| ---: | --- | --- |
| 68 | `UselessParentheses` | Dropped the redundant outer parentheses in the `MD4` rounds and helpers, the `Envelopes` SOAP builders, and the boolean/bitwise returns of `WsmanClient`, `WinRMEndpoint`, `NTLMMessage`, `Type1Message`, `WmiHelper` and `ShellFileCopy`. |
| 11 | `UnnecessaryModifier` | Removed `public` on interface methods and `final` on try-with-resources variables. |
| 6 | `EmptyCatchBlock` | Renamed the caught exception to `ignored`, the name PMD accepts for a deliberately ignored exception (`allowExceptionNameRegex`), keeping the existing explanatory comments. `Type3Message`'s genuinely empty block also gained a comment: a missing SHA1PRNG leaves `RND_GEN` null and the constructor reports it. |
| 2 | `AvoidBranchingStatementAsLastInLoop` | `NtlmCrypto.Cursor.skipUntil` now loops on a new `matchesAt(...)` predicate instead of a labelled `continue`/`return`; `WsmanClient.request` accumulates into a `Decoded` sentinel and returns after the retry loop. |
| 1 | `EmptyControlStatement` | `HttpTransport.readChunked` reads the next trailer line in the loop body rather than in the condition. |
| 1 | `UnusedFormalParameter` | Removed the unused `target` parameter from the `CipherGen` constructor and its single call site. |
| 2 | `UnusedPrivateMethod` | Not in the issue's list — these two only surface when PMD's type resolution is degraded, but they are in the report on my checkout, and both are false positives on used methods. Renamed the private `collectItems` overload to `collectRows` so PMD resolves the call, and annotated `RemoteDigest.matches`, which PMD cannot see through `Optional#get()`, with a justified `@SuppressWarnings`. |

The issue left open whether the `light/*` NTLM/crypto ports should get a targeted suppression instead. I went with the mechanical fix: those files are already reformatted to the project's style, so they are not byte-comparable with upstream anyway, and removing the parentheses is provably semantics-preserving. Happy to switch them to a class-level suppression if you would rather keep them close to the fork.

## Tests

Everything above is behavior-preserving, and the NTLM paths (`MD4`, `NtlmCrypto`, `WsmanClient.request`, `Envelopes`) are covered end to end by the existing `WsmanProtocolTest` against `FakeWsmanServer`.

The one gap was the trailer-draining path rewritten in `readChunked`, which had no coverage. `FakeWsmanServer` gained a chunked-response mode (several chunks, a chunk extension, trailer fields after the terminating chunk) and `WsmanProtocolTest` a test that pages a WQL enumeration over it — a client that leaves the trailers in the socket desyncs the kept-alive NTLM connection and fails on the *following* request. I checked the test's sensitivity by deliberately truncating the drain, which makes it fail.

## Verification

- PMD 7.7.0: **0 violations**. Checkstyle: **0**.
- SpotBugs: 36, down from 37 on `main` (the `Type3Message` empty catch), nothing new. Run with plugin 4.9.8.0 because the pinned version cannot read Java 25 bytecode on my machine.
- `mvn test`: 83 tests (was 82), all passing except `WinRmCliTest.decodesCommandOutputUsingTheRemoteWindowsCodePage` and `WinRMWqlExecutorTest.testExecute`, which fail identically on unmodified `main` here — Mockito's inline mock maker refuses to mock under JDK 25.
- Heads-up on the "`mvn verify site` still green" criterion: I could not confirm it locally, because SpotBugs and the site skin both break under JDK 25 (`Unsupported class file major version 69`, `sun.misc.Unsafe.ensureClassInitialized`) before and after these changes. It needs a CI run on a supported JDK.

`CipherGen` is a `public` class, so dropping a constructor parameter is technically a signature change; it is internal NTLM plumbing with a single caller, and I noted it in `CHANGELOG.md` under the in-progress 2.0.0 section. No README change: nothing here is visible to users of the documented API.

`pmd:check` is enabled in this PR (see the comment below), so the report cannot silently regress.
