### PR TITLE
Fix the 2 CPD duplications reported by the Maven site

### DIFF
--- a/src/main/java/org/metricshub/winrm/light/CipherGen.java
+++ b/src/main/java/org/metricshub/winrm/light/CipherGen.java
@@ -519,6 +519,10 @@ public class CipherGen {
 	 *         Responses.
 	 */
 	private static byte[] ntlmv2Hash(final String domain, final String user, final byte[] ntlmHash) throws NtlmException {
+		// CPD-OFF — near-duplicate of lmv2Hash() by design: both mirror the reference NTLM
+		// implementation (Apache HttpClient's NTLMEngineImpl), kept line-for-line comparable with
+		// upstream rather than factored through a shared helper. The one divergence is deliberate
+		// and easy to miss: LMv2 upper-cases the domain, NTLMv2 keeps its case.
 		if (NTLMEngineUtils.UNICODE_LITTLE_UNMARKED == null) {
 			throw new NtlmException("Unicode not supported");
 		}
@@ -529,6 +533,7 @@ public class CipherGen {
 			hmacMD5.update(domain.getBytes(NTLMEngineUtils.UNICODE_LITTLE_UNMARKED));
 		}
 		return hmacMD5.getOutput();
+		// CPD-ON
 	}
 
 	/**

--- a/src/main/java/org/metricshub/winrm/light/LightWinRMService.java
+++ b/src/main/java/org/metricshub/winrm/light/LightWinRMService.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -167,24 +168,17 @@ public final class LightWinRMService implements WindowsRemoteExecutor {
 
 		// Enforce the caller's timeout as a wall-clock deadline (throwing TimeoutException), matching
 		// the CXF WinRMService and bounding the WSMan Pull loop.
-		try {
-			return Utils.execute(
-				() -> {
-					final List<Map<String, String>> rows = client.wql(winRMEndpoint.getNamespace(), wqlQuery);
-					final List<Map<String, Object>> result = new ArrayList<>(rows.size());
-					for (final Map<String, String> row : rows) {
-						result.add(new LinkedHashMap<>(row));
-					}
-					return result;
-				},
-				timeout
-			);
-		} catch (final InterruptedException | ExecutionException e) {
-			if (e.getCause() != null) {
-				throw new WinRMException(e.getCause(), e.getCause().getMessage());
-			}
-			throw new WinRMException(e);
-		}
+		return executeWithTimeout(
+			() -> {
+				final List<Map<String, String>> rows = client.wql(winRMEndpoint.getNamespace(), wqlQuery);
+				final List<Map<String, Object>> result = new ArrayList<>(rows.size());
+				for (final Map<String, String> row : rows) {
+					result.add(new LinkedHashMap<>(row));
+				}
+				return result;
+			},
+			timeout
+		);
 	}
 
 	@Override
@@ -200,16 +194,34 @@ public final class LightWinRMService implements WindowsRemoteExecutor {
 
 		// Enforce the caller's timeout as a wall-clock deadline (throwing TimeoutException), matching
 		// the CXF WinRMService and bounding the WSMan Receive loop.
+		return executeWithTimeout(
+			() -> {
+				final long start = Utils.getCurrentTimeMillis();
+				final WsmanClient.CommandOutput output = client.executeCommand(command, workingDirectory, charset);
+				final float executionTime = (Utils.getCurrentTimeMillis() - start) / 1000.0f;
+				return new WindowsRemoteCommandResult(output.stdout, output.stderr, executionTime, output.exitCode);
+			},
+			timeout
+		);
+	}
+
+	/**
+	 * Run the task through {@link Utils#execute(Callable, long)} under the caller's wall-clock
+	 * timeout, converting the executor's checked exceptions into {@link WinRMException} — the
+	 * task's own failure is unwrapped from {@link ExecutionException} so the caller sees the real
+	 * cause and its message.
+	 *
+	 * @param task the operation to run
+	 * @param timeout timeout in milliseconds
+	 * @param <T> the task's result type
+	 * @return the task's result
+	 * @throws TimeoutException when the deadline elapses first
+	 * @throws WinRMException when the task fails or the wait is interrupted
+	 */
+	private static <T> T executeWithTimeout(final Callable<T> task, final long timeout)
+		throws TimeoutException, WinRMException {
 		try {
-			return Utils.execute(
-				() -> {
-					final long start = Utils.getCurrentTimeMillis();
-					final WsmanClient.CommandOutput output = client.executeCommand(command, workingDirectory, charset);
-					final float executionTime = (Utils.getCurrentTimeMillis() - start) / 1000.0f;
-					return new WindowsRemoteCommandResult(output.stdout, output.stderr, executionTime, output.exitCode);
-				},
-				timeout
-			);
+			return Utils.execute(task, timeout);
 		} catch (final InterruptedException | ExecutionException e) {
 			if (e.getCause() != null) {
 				throw new WinRMException(e.getCause(), e.getCause().getMessage());


### PR DESCRIPTION
## What

Resolves the 2 duplicated blocks flagged by the CPD report (closes #123):

1. **`LightWinRMService.java`** — genuine duplication: `executeWql` and `executeCommand` shared an identical `catch (InterruptedException | ExecutionException)` → `WinRMException` unwrap-and-wrap tail around `Utils.execute(...)`. Extracted into a private `executeWithTimeout(Callable<T>, long)` helper. Behavior is unchanged: same exception unwrapping, same messages.

2. **`CipherGen.java`** — intentional duplication: `lmv2Hash()` and `ntlmv2Hash()` share an identical prologue because both mirror the reference NTLM implementation (Apache HttpClient's `NTLMEngineImpl`). As discussed in the issue, this code is deliberately kept line-for-line comparable with upstream rather than factored through a shared helper, so the duplicated block in `ntlmv2Hash()` is narrowly suppressed with `// CPD-OFF` / `// CPD-ON` comments. The suppression comment documents the rationale and the easy-to-miss deliberate divergence between the two methods (LMv2 upper-cases the domain, NTLMv2 keeps its case).

## Why

The CPD page of the Maven site flagged these 2 duplications; the report is now clean.

## Verification

- `target/cpd.xml` reports **0 duplications**.
- `mvn verify site` green on JDK 17 (like CI): 79 unit tests + 1 IT pass, checkstyle/pmd/spotbugs gates all pass.
- Code formatted with `mvn formatter:format`.

## Reviewer notes

- The CPD suppression only covers the duplicated block inside `ntlmv2Hash()`; the rest of `CipherGen` remains fully analyzed.
- No user-facing change, so no README update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)