### PR TITLE
Fix truncated authentication.html: promote Ordered fallback to h2

### DIFF
--- a/src/site/markdown/authentication.md
+++ b/src/site/markdown/authentication.md
@@ -23,7 +23,7 @@ WinRMClient.builder("server.example.com")
 
 When `authentication(...)` is not called, **NTLM** is used.
 
-### Ordered fallback
+## Ordered fallback
 
 Several schemes form an **ordered fallback list**: each is tried in the given order until one
 succeeds. `authentication(KERBEROS, NTLM)` attempts Kerberos first and falls back to NTLM — for


### PR DESCRIPTION
Fixes #153

## Problem

https://metricshub.org/winrm-java/authentication.html only renders the introduction — everything from "Ordered fallback" to "See also" is missing from the generated HTML, and the sidebar TOC contains a broken `href="#null"` entry.

## Cause

`authentication.md` had `### Ordered fallback` directly under the top-level `#` title with no `##` parent section. Doxia's section nesting cannot handle the h1 → h3 skip followed by a return to h2: it emits an empty `<section></section>` and silently drops the rest of the page.

## Fix

Promote the heading to `## Ordered fallback`. A scan of all pages under `src/site/markdown/` confirms this was the only heading-level skip in the site.

## Verification

Rebuilt the site locally with `mvn site`: the regenerated `authentication.html` now contains all seven sections (Ordered fallback, User name and domain, NTLM, Kerberos (SPNEGO), Authentication failures, Choosing the scheme on the command line, See also), the Kerberos configuration subsection, and the CLI options table, with no `#null` TOC entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)